### PR TITLE
Google logo color changes

### DIFF
--- a/src/client/ReportPage.js
+++ b/src/client/ReportPage.js
@@ -194,7 +194,7 @@ function AddGoogleAttribution() {
   useEffect(() => {
     if (kepler) {
       const { mapStyle : { styleType }} = kepler
-      styleType === 'dark' || styleType === 'light' ? toggleUseColoredLogo(true) : toggleUseColoredLogo(false)
+      styleType === 'streets2d' || styleType === 'light' || styleType === 'terrain' ? toggleUseColoredLogo(true) : toggleUseColoredLogo(false)
     }
   }, [kepler])
   const imgFile = useColoredLogo ? 'google_on_white.png' : 'google_on_non_white.png'


### PR DESCRIPTION
Displays the color logo on street, terrain and light styles and the white logo on satellite, hybrid and dark styles.